### PR TITLE
Beta 2. Add support for strict-dynamic, fix existing nonce bug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ Finally, add DCN directives to settings:
 
     CSP_NONCE_SCRIPT = False  # True if you want to use it
     CSP_NONCE_STYLE = False  # True if you want to use it
+    CSP_FLAG_STRICT = False  # True to include strict-dynamic in CSP
 
 Usage
 -----

--- a/csp_nonce/middleware.py
+++ b/csp_nonce/middleware.py
@@ -35,9 +35,9 @@ class CSPNonceMiddleware(MiddlewareMixin):
             if not header:
                 return response
 
-            has_nonce = nonce_exists(response)
-            if bool(has_nonce):
-                LOG.error("Nonce already exists: {}".format(has_nonce))
+            nonce_found, has_nonce = nonce_exists(response)
+            if has_nonce:
+                LOG.error("Nonce already exists: {}".format(nonce_found))
                 return response
 
             nonce_request = {

--- a/csp_nonce/middleware.py
+++ b/csp_nonce/middleware.py
@@ -36,7 +36,7 @@ class CSPNonceMiddleware(MiddlewareMixin):
                 return response
 
             has_nonce = nonce_exists(response)
-            if has_nonce:
+            if bool(has_nonce):
                 LOG.error("Nonce already exists: {}".format(has_nonce))
                 return response
 
@@ -45,6 +45,8 @@ class CSPNonceMiddleware(MiddlewareMixin):
                 'style':  getattr(request, 'style_nonce', None)
             }
 
+            csp_flag_strict = getattr(settings, 'CSP_FLAG_STRICT', False)
+
             csp_split = header['csp'].split(';')
             new_csp = []
 
@@ -52,6 +54,8 @@ class CSPNonceMiddleware(MiddlewareMixin):
                 for x in ('script', 'style'):
                     if p.lstrip().startswith(x) and nonce_request[x]:
                         p += " 'nonce-{}'".format(nonce_request[x])
+                        if x == 'script' and csp_flag_strict:
+                            p += " 'strict-dynamic'"
                 new_csp.append(p)
 
             response[header['name']] = ";".join(new_csp)

--- a/csp_nonce/utils.py
+++ b/csp_nonce/utils.py
@@ -22,9 +22,9 @@ def nonce_exists(response):
     if csp:
         csp_split = csp.split(';')
         for directive in csp_split:
-            if 'script-src' and 'nonce-' in directive:
+            if all(map(lambda p: p in directive, ['script-src', 'nonce-'])):
                 nonce_found['script'] = directive
-            if 'style-src' and 'nonce-' in directive:
+            if all(map(lambda p: p in directive, ['style-src', 'nonce-'])):
                 nonce_found['style'] = directive
 
     return nonce_found

--- a/csp_nonce/utils.py
+++ b/csp_nonce/utils.py
@@ -22,12 +22,16 @@ def nonce_exists(response):
     if csp:
         csp_split = csp.split(';')
         for directive in csp_split:
-            if all(map(lambda p: p in directive, ['script-src', 'nonce-'])):
+            if 'nonce-' not in directive:
+                continue
+            if 'script-src' in directive:
                 nonce_found['script'] = directive
-            if all(map(lambda p: p in directive, ['style-src', 'nonce-'])):
+            if 'style-src' in directive:
                 nonce_found['style'] = directive
 
-    return nonce_found
+    has_nonce = any(nonce_found)
+
+    return nonce_found, has_nonce
 
 
 def get_header(response):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 from setuptools import setup, find_packages
 
 
-version = '1.0b10'
+version = '1.0b2'
 
 
 if sys.argv[-1] == 'publish':

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import codecs
 from setuptools import setup, find_packages
 
 
-version = '1.0b2'
+version = '1.0b20'
 
 
 if sys.argv[-1] == 'publish':

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -6,6 +6,7 @@ CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "*.styles.trustedurl.com")
 
 CSP_NONCE_SCRIPT = False
 CSP_NONCE_STYLE = False
+CSP_FLAG_STRICT = False
 
 
 INSTALLED_APPS = (

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -90,6 +90,18 @@ def test_existing_nonce():
     nmw.process_request(request)
 
     response = HttpResponse()
-    response[HEADER] = "script-src 'self' 'nonce=123A/B+c'"
+    response[HEADER] = "script-src 'self' 'nonce-123A/B+c'"
+    nmw.process_response(request, response)
 
     assert request.script_nonce not in response[HEADER]
+
+
+@override_settings(CSP_NONCE_SCRIPT=True, CSP_FLAG_STRICT=True)
+def test_strict_dynamic_addition():
+    request = rf.get('/')
+    nmw.process_request(request)
+
+    response = HttpResponse()
+    response[HEADER] = CSP
+    nmw.process_response(request, response)
+    assert 'strict-dynamic' in response[HEADER]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ class TestUtils(unittest.TestCase):
             "style-src 'self' 'unsafe-inline'"
         response = HttpResponse()
         response['Content-Security-Policy'] = csp
-        self.assertTrue(utils.nonce_exists(response))
+        self.assertIsNotNone(utils.nonce_exists(response))
 
     def test_nonce_esists_style(self):
         csp = "sctipt-src *.goof.com" + \

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,16 +24,38 @@ class TestUtils(unittest.TestCase):
             response['Content-Security-Policy']
             response['Content-Security-Policy-Report-Only']
 
-    def test_nonce_esists_script(self):
-        csp = "sctipt-src *.goof.com 'nonce-123/AB+C';" + \
-            "style-src 'self' 'unsafe-inline'"
+    def test_nonce_exists_script(self):
+        csp = "script-src *.goof.com 'nonce-123/AB+C';" + \
+            " style-src 'self' 'unsafe-inline';"
         response = HttpResponse()
         response['Content-Security-Policy'] = csp
-        self.assertIsNotNone(utils.nonce_exists(response))
+        nonce_found, has_nonce = utils.nonce_exists(response)
+        self.assertTrue(has_nonce)
+        self.assertEqual(
+            "script-src *.goof.com 'nonce-123/AB+C'",
+            nonce_found['script']
+        )
+        self.assertIsNone(nonce_found.get('style', None))
 
-    def test_nonce_esists_style(self):
-        csp = "sctipt-src *.goof.com" + \
-            "style-src 'self' https://stuff.things.com 'nonce-123/AB+C';"
+    def test_nonce_exists_style(self):
+        csp = "sctipt-src *.goof.com;" + \
+            " style-src 'self' https://stuff.things.com 'nonce-123/AB+C';"
         response = HttpResponse()
         response['Content-Security-Policy'] = csp
-        self.assertTrue(utils.nonce_exists(response))
+        nonce_found, has_nonce = utils.nonce_exists(response)
+        self.assertTrue(has_nonce)
+        self.assertEqual(
+            " style-src 'self' https://stuff.things.com 'nonce-123/AB+C'",
+            nonce_found['style']
+        )
+        self.assertIsNone(nonce_found.get('script', None))
+
+    def test_nonce_exists_empty(self):
+        csp = "default-src *.goof.com;" + \
+            " font-src 'self' https://stuff.things.com;"
+        response = HttpResponse()
+        response['Content-Security-Policy'] = csp
+        nonce_found, has_nonce = utils.nonce_exists(response)
+        self.assertFalse(has_nonce)
+        self.assertIsNone(nonce_found.get('script', None))
+        self.assertIsNone(nonce_found.get('style', None))


### PR DESCRIPTION
This adds `strict-dynamic` to the `script-src` directive if `CSP_FLAG_STRICT` is enabled.
In the case of strict-dynamic for default-src, I think that may fall outside the scope of this project. 

As I was working on this, I found a hole in preexisting nonce checking. So I went ahead and took care of that in the process.