### PR TITLE
Use ~~pycrypto~~ os.urandom() instead of pyNacl for random generation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,3 +96,13 @@ Known issues
 
 .. |Build Status| image:: https://travis-ci.org/Bennyoak/django-csp-nonce.svg?branch=master
    :target: https://travis-ci.org/Bennyoak/django-csp-nonce
+
+
+Important Changes
+-----------------
+
+- 1.0
+  - Out of beta!
+  - PyNacl is no longer a dependency.  (Moving forward the aim is to
+    stay compatible with environments such as Google App Engine which
+    don't support non-python extensions.)

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,6 @@ Disclosure
 -  This code has not been through a third party security audit.
 -  I’ve successfully tested this locally with ``pypy-5.4.1``. TravisCI
    has confirmed this doesn’t work with their version.
--  From their logs:
-   ``RuntimeError: PyNaCl is not compatible with PyPy < 2.6. Please upgrade PyPy to use this library.``
 
 Installation
 ------------
@@ -71,7 +69,7 @@ Finally, add DCN directives to settings:
 Usage
 -----
 
-DCN takes care of nonce generation for you using `pynacl`_. As you work
+DCN takes care of nonce generation for you. As you work
 on your templates, pull in your specific nonce from the context:
 
 .. code:: django
@@ -87,7 +85,6 @@ on your templates, pull in your specific nonce from the context:
 Dependencies
 ------------
 
--  PyNacl
 -  Django
 
 Known issues
@@ -96,7 +93,6 @@ Known issues
 -  Nonce sync breaks on ``settings.DEBUG=True``
 
 .. _Django-CSP: http://django-csp.readthedocs.io/en/latest/
-.. _pynacl: https://github.com/pyca/pynacl
 
 .. |Build Status| image:: https://travis-ci.org/Bennyoak/django-csp-nonce.svg?branch=master
    :target: https://travis-ci.org/Bennyoak/django-csp-nonce

--- a/csp_nonce/utils.py
+++ b/csp_nonce/utils.py
@@ -1,13 +1,14 @@
 from __future__ import unicode_literals
 import base64
-import nacl.secret
-import nacl.utils
+import os
 
+# Number of random bytes in the nonce:
+NONCE_BYTES = 24
 
 def generate_nonce():
-    """ Return a unique base64 encoded nonce hash """
-    nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
-    return "{}".format(base64.b64encode(nonce))
+    """ Return a unique base64 encoded nonce hash."""
+    nonce = os.urandom(NONCE_BYTES)
+    return base64.b64encode(nonce).decode()
 
 
 def nonce_exists(response):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def read(*parts):
 
 install_requires = [
     'Django>=1.6,<1.11',
-    'pynacl==1.0.1'
 ]
 
 


### PR DESCRIPTION
pycrypto allows this library to be used on App Engine (which doesn't support
ffi which is required for pyNacl.)